### PR TITLE
chore: resolve released jwt dependency

### DIFF
--- a/jwe/go.sum
+++ b/jwe/go.sum
@@ -2,3 +2,5 @@ github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/mkbeh/xjose/jwt v0.2.0 h1:9WcF/npBX0Hu/oJ/fJQ6UxEEp+aW7e2EHEvUDnyzPSk=
+github.com/mkbeh/xjose/jwt v0.2.0/go.mod h1:9Pf9KGmwrh5dIG/48FaTvAiDSota0lu5sGFDK6xjj5A=

--- a/jwk/go.sum
+++ b/jwk/go.sum
@@ -2,3 +2,5 @@ github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/mkbeh/xjose/jwt v0.2.0 h1:9WcF/npBX0Hu/oJ/fJQ6UxEEp+aW7e2EHEvUDnyzPSk=
+github.com/mkbeh/xjose/jwt v0.2.0/go.mod h1:9Pf9KGmwrh5dIG/48FaTvAiDSota0lu5sGFDK6xjj5A=


### PR DESCRIPTION
## Summary

- resolve `github.com/mkbeh/xjose/jwt v0.2.0` outside the local workspace;
- update checksums for the `jwk` and `jwe` modules;
- verify both dependent modules with `GOWORK=off`.